### PR TITLE
stop using acpi_video_set_dmi_backlight_type, support linux kernel 6.1

### DIFF
--- a/apple-gmux.c
+++ b/apple-gmux.c
@@ -22,9 +22,13 @@
 #include <linux/delay.h>
 #include <linux/pci.h>
 #include <linux/vga_switcheroo.h>
-#include <acpi/video.h>
 #include <asm/io.h>
 #include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	#include <acpi/video.h>
+#endif
+
 
 /**
  * DOC: Overview
@@ -855,9 +859,6 @@ static int gmux_probe(struct pnp_dev *pnp, const struct pnp_device_id *id)
 	// linux kernel 6.1, deprecated acpi_video_set_dmi_backlight_type
 	#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
 		acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);
-	#else
-		if (acpi_video_get_backlight_type() != acpi_backlight_vendor)
-			return 0;
 	#endif
 
 	apple_bl_unregister();
@@ -975,8 +976,9 @@ static void gmux_remove(struct pnp_dev *pnp)
 		release_region(gmux_data->iostart, gmux_data->iolen);
 	apple_gmux_data = NULL;
 	kfree(gmux_data);
-
-	acpi_video_register();
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)	
+		acpi_video_register();
+	#endif
 	apple_bl_register();
 }
 

--- a/apple-gmux.c
+++ b/apple-gmux.c
@@ -24,6 +24,7 @@
 #include <linux/vga_switcheroo.h>
 #include <acpi/video.h>
 #include <asm/io.h>
+#include <linux/version.h>
 
 /**
  * DOC: Overview
@@ -852,10 +853,12 @@ static int gmux_probe(struct pnp_dev *pnp, const struct pnp_device_id *id)
 	 * Disable the other backlight choices.
 	 */
 	// linux kernel 6.1, deprecated acpi_video_set_dmi_backlight_type
-	// acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);
-	
-	if (acpi_video_get_backlight_type() != acpi_backlight_vendor)
-		return 0;
+	#if LINUX_VERSION_CODE < KERNEL_VERSION(6,1,0)
+		acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);
+	#else
+		if (acpi_video_get_backlight_type() != acpi_backlight_vendor)
+			return 0;
+	#endif
 
 	apple_bl_unregister();
 

--- a/apple-gmux.c
+++ b/apple-gmux.c
@@ -851,7 +851,12 @@ static int gmux_probe(struct pnp_dev *pnp, const struct pnp_device_id *id)
 	 * backlight control and supports more levels than other options.
 	 * Disable the other backlight choices.
 	 */
-	acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);
+	// linux kernel 6.1, deprecated acpi_video_set_dmi_backlight_type
+	// acpi_video_set_dmi_backlight_type(acpi_backlight_vendor);
+	
+	if (acpi_video_get_backlight_type() != acpi_backlight_vendor)
+		return 0;
+
 	apple_bl_unregister();
 
 	gmux_data->power_state = VGA_SWITCHEROO_ON;


### PR DESCRIPTION
As of Linux kernel 6.1, acpi_video_set_dmi_backlight_type is no longer available. 
https://lore.kernel.org/lkml/b23c765b-4999-17a4-d89a-55d6ba72f68d@redhat.com/